### PR TITLE
Use hello world permission instead of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ ddev launch /admin/reports/status
 Install the site using any installation profile. Enable the `hello_world` module and go to `/hello`. Anyone (including anonymous users) should see a welcome message, but a page not found error is presented instead. Why?
 
 ```
-ddev drush --yes site:install moonshot
+ddev drush site:install --yes --account-pass=admin demo_umami
 ddev drush pm:enable hello_world
 ddev launch /hello
 ```
 
 ## Permission not being detected
 
-Install the site using any installation profile. Enable the `hello_world` module. The module is supposed to expose a permission named `Example permission`, but it is not being detected. Go to the permissions page and verify that is the case. Why?
+Install the site using any installation profile. Enable the `hello_world` module. The module is supposed to expose a permission named `Hello world allowed`, but it is not being detected. Go to the permissions page and verify the problem. Why?
 
 ```
-ddev drush --yes site:install moonshot
+ddev drush site:install --yes --account-pass=admin demo_umami
 ddev drush pm:enable hello_world
 ddev launch $(ddev drush uli)
 ddev launch /admin/people/permissions

--- a/web/modules/custom/hello_world/hello_world.info.yml
+++ b/web/modules/custom/hello_world/hello_world.info.yml
@@ -1,5 +1,5 @@
 name: 'Hello World'
 type: module
-description: 'Example module.'
+description: 'Simple example that does nothing but hello world.'
 package: Example
 core_version_requirement: ^10 || ^11

--- a/web/modules/custom/hello_world/hello_world.permissions.yaml
+++ b/web/modules/custom/hello_world/hello_world.permissions.yaml
@@ -1,2 +1,2 @@
-example permission:
-  title: 'Example permission'
+hello world allowed:
+  title: 'Hello world allowed'

--- a/web/modules/custom/hello_world/hello_world.routing.yml
+++ b/web/modules/custom/hello_world/hello_world.routing.yml
@@ -1,7 +1,7 @@
 hello_world.salute:
   path: '/hello'
   defaults:
-    _title: 'Hello'
+    _title: 'Hello WORLD!!!'
   _controller: '\Drupal\hello_world\Controller\HelloWorldController::salute'
   requirements:
     _access: 'TRUE'

--- a/web/modules/custom/hello_world/src/Controller/HelloWorldController.php
+++ b/web/modules/custom/hello_world/src/Controller/HelloWorldController.php
@@ -18,7 +18,7 @@ final class HelloWorldController extends ControllerBase {
 
     $build['content'] = [
       '#type' => 'item',
-      '#markup' => $this->t('Yay, it works!'),
+      '#markup' => $this->t('HELLO WORLD! Yay, it works!'),
     ];
 
     return $build;


### PR DESCRIPTION
I was slightly lost looking for the permission because I expected something about "hello world", so changing the permission name to imply the module here.